### PR TITLE
Borrow safe Solis sensor mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Unsupported model-specific values become unavailable/empty; they should not brea
 
 ## Features
 
-- Polls the Solis Cloud `/v1/api/inverterDetail` endpoint every 60 seconds.
+- Polls the Solis Cloud `/v1/api/inverterDetail` endpoint every 60 seconds, with `/v1/api/stationDetail` as a fallback source for station-level grid/load energy values.
 - Discovers up to five inverters linked to the API user automatically.
 - Supports clean v2 sensors for inverter production, PV strings, grid AC, battery/storage, load/backup, and grid import/export telemetry.
 - Adds conservative night-noise handling for tiny phantom AC production values when PV/DC evidence indicates no generation.
@@ -103,6 +103,7 @@ Each inverter appears as a separate Home Assistant device with manufacturer, mod
 
 - `pv1_voltage` V, `pv1_current` A, `pv1_power` W
 - `pv2_voltage` V, `pv2_current` A, `pv2_power` W
+- `pv3_*` through `pv24_*` are also created for larger multi-string inverters when SolisCloud reports those fields
 
 ### Grid AC
 
@@ -137,8 +138,12 @@ Each inverter appears as a separate Home Assistant device with manufacturer, mod
 ### Grid import/export, supported models only
 
 - `grid_import_today_energy` kWh
+- `grid_import_month_energy` kWh
+- `grid_import_year_energy` kWh
 - `grid_import_total_energy` kWh
 - `grid_export_today_energy` kWh
+- `grid_export_month_energy` kWh
+- `grid_export_year_energy` kWh
 - `grid_export_total_energy` kWh
 
 ### Diagnostics

--- a/custom_components/solis_cloud_monitoring/api.py
+++ b/custom_components/solis_cloud_monitoring/api.py
@@ -1,4 +1,5 @@
 """API client for Solis Cloud."""
+
 from __future__ import annotations
 
 import asyncio
@@ -12,7 +13,12 @@ from typing import Any
 
 import aiohttp
 
-from .const import API_BASE_URL, API_INVERTER_DETAIL, API_INVERTER_LIST
+from .const import (
+    API_BASE_URL,
+    API_INVERTER_DETAIL,
+    API_INVERTER_LIST,
+    API_STATION_DETAIL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +37,7 @@ class SolisCloudAPI:
         session: aiohttp.ClientSession,
     ) -> None:
         """Initialize the API client.
-        
+
         Args:
             api_key: Solis Cloud API key
             api_secret: Solis Cloud API secret
@@ -43,11 +49,11 @@ class SolisCloudAPI:
 
     def _generate_headers(self, body: str, endpoint: str) -> dict[str, str]:
         """Generate authentication headers for API request.
-        
+
         Args:
             body: JSON request body
             endpoint: API endpoint path
-            
+
         Returns:
             Dictionary of HTTP headers
         """
@@ -84,14 +90,14 @@ class SolisCloudAPI:
         self, endpoint: str, payload: dict[str, Any]
     ) -> dict[str, Any] | None:
         """Make authenticated API request.
-        
+
         Args:
             endpoint: API endpoint path
             payload: Request payload
-            
+
         Returns:
             Response data or None on error
-            
+
         Raises:
             SolisCloudAPIError: On API or network errors
         """
@@ -131,10 +137,10 @@ class SolisCloudAPI:
 
     async def get_inverter_list(self) -> list[dict[str, Any]]:
         """Get list of all inverters on the account.
-        
+
         Returns:
             List of inverter information dictionaries
-            
+
         Raises:
             SolisCloudAPIError: On API or network errors
         """
@@ -149,22 +155,32 @@ class SolisCloudAPI:
 
     async def get_inverter_details(self, serial_number: str) -> dict[str, Any]:
         """Get detailed information for a specific inverter.
-        
+
         Args:
             serial_number: Inverter serial number
-            
+
         Returns:
             Inverter details dictionary
-            
+
         Raises:
             SolisCloudAPIError: On API or network errors
         """
         data = await self._request(API_INVERTER_DETAIL, {"sn": serial_number})
 
         if not data:
-            raise SolisCloudAPIError(
-                f"No data returned for inverter {serial_number}"
-            )
+            raise SolisCloudAPIError(f"No data returned for inverter {serial_number}")
 
         _LOGGER.debug("Retrieved details for inverter %s", serial_number)
+        return data
+
+    async def get_station_details(self, station_id: str) -> dict[str, Any]:
+        """Get plant/station level data used for grid/load energy fallbacks."""
+        data = await self._request(API_STATION_DETAIL, {"id": station_id})
+
+        if not data:
+            raise SolisCloudAPIError(
+                f"No station data returned for station {station_id}"
+            )
+
+        _LOGGER.debug("Retrieved station details for station %s", station_id)
         return data

--- a/custom_components/solis_cloud_monitoring/const.py
+++ b/custom_components/solis_cloud_monitoring/const.py
@@ -1,4 +1,5 @@
 """Constants for the Solis Cloud Monitoring integration."""
+
 from datetime import timedelta
 from typing import Final
 
@@ -13,6 +14,7 @@ CONF_INVERTER_SERIALS: Final = "inverter_serials"
 API_BASE_URL: Final = "https://www.soliscloud.com:13333"
 API_INVERTER_LIST: Final = "/v1/api/inverterList"
 API_INVERTER_DETAIL: Final = "/v1/api/inverterDetail"
+API_STATION_DETAIL: Final = "/v1/api/stationDetail"
 
 # Limits
 MAX_INVERTERS: Final = 5

--- a/custom_components/solis_cloud_monitoring/coordinator.py
+++ b/custom_components/solis_cloud_monitoring/coordinator.py
@@ -1,4 +1,5 @@
 """Data update coordinator for Solis Cloud Monitoring."""
+
 from __future__ import annotations
 
 import logging
@@ -13,6 +14,25 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+def _merge_station_detail(
+    inverter_data: dict[str, Any], station_data: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Return inverter detail plus namespaced station-level Solis fields.
+
+    hultenvp/solis-sensor reads both inverterDetail and stationDetail. Keep
+    inverterDetail authoritative and add station fields under a prefix so same
+    named keys cannot silently overwrite inverter telemetry.
+    """
+    merged = dict(inverter_data)
+    if not station_data:
+        return merged
+
+    for key, value in station_data.items():
+        if value not in (None, ""):
+            merged[f"station_{key}"] = value
+    return merged
+
+
 class SolisCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
     """Class to manage fetching Solis Cloud data."""
 
@@ -22,13 +42,7 @@ class SolisCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, 
         api: SolisCloudAPI,
         inverter_serials: list[str],
     ) -> None:
-        """Initialize the coordinator.
-        
-        Args:
-            hass: Home Assistant instance
-            api: Solis Cloud API client
-            inverter_serials: List of inverter serial numbers to monitor
-        """
+        """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
@@ -39,25 +53,40 @@ class SolisCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, 
         self.inverter_serials = inverter_serials
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
-        """Fetch data from Solis Cloud API.
-        
-        Returns:
-            Dictionary mapping serial numbers to inverter data
-            
-        Raises:
-            UpdateFailed: When update fails
-        """
+        """Fetch data from Solis Cloud API."""
         data: dict[str, dict[str, Any]] = {}
+        station_cache: dict[str, dict[str, Any] | None] = {}
 
         try:
-            # Fetch data for each inverter
             for serial in self.inverter_serials:
                 try:
                     inverter_data = await self.api.get_inverter_details(serial)
+                    station_data = None
+                    station_id = inverter_data.get("stationId")
+                    if station_id not in (None, ""):
+                        station_id = str(station_id)
+                        if station_id not in station_cache:
+                            try:
+                                station_cache[station_id] = (
+                                    await self.api.get_station_details(station_id)
+                                )
+                            except SolisCloudAPIError as err:
+                                station_cache[station_id] = None
+                                _LOGGER.debug(
+                                    "Failed to update station %s details: %s",
+                                    station_id,
+                                    err,
+                                )
+                        station_data = station_cache[station_id]
+
+                    inverter_data = _merge_station_detail(inverter_data, station_data)
                     data[serial] = inverter_data
+
                     pac_value = inverter_data.get("pac")
                     try:
-                        pac_float = float(pac_value) if pac_value not in (None, "") else None
+                        pac_float = (
+                            float(pac_value) if pac_value not in (None, "") else None
+                        )
                     except (TypeError, ValueError):
                         pac_float = None
 
@@ -70,10 +99,7 @@ class SolisCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, 
                     else:
                         _LOGGER.debug("Updated data for inverter %s", serial)
                 except SolisCloudAPIError as err:
-                    _LOGGER.warning(
-                        "Failed to update inverter %s: %s", serial, err
-                    )
-                    # Continue with other inverters even if one fails
+                    _LOGGER.warning("Failed to update inverter %s: %s", serial, err)
                     continue
 
             if not data:
@@ -82,4 +108,6 @@ class SolisCloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, 
             return data
 
         except SolisCloudAPIError as err:
-            raise UpdateFailed(f"Error communicating with Solis Cloud API: {err}") from err
+            raise UpdateFailed(
+                f"Error communicating with Solis Cloud API: {err}"
+            ) from err

--- a/custom_components/solis_cloud_monitoring/sensor.py
+++ b/custom_components/solis_cloud_monitoring/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Solis Cloud Monitoring v2."""
+
 from __future__ import annotations
 
 import logging
@@ -134,8 +135,6 @@ def _energy_to_kwh(
     return value
 
 
-
-
 def _hide_grid_only_zero(data: dict[str, Any], value: float | None) -> float | None:
     """Hide zero-valued hybrid/storage fields on explicit grid-only models.
 
@@ -179,6 +178,7 @@ def _model_float(data: dict[str, Any], *keys: str) -> float | None:
     """Return optional model-specific float, hiding unsupported grid-only zeros."""
     return _hide_grid_only_zero(data, _fallback_float(data, *keys))
 
+
 def _fallback_power_to_watts(
     data: dict[str, Any],
     candidates: tuple[tuple[str, str | None, str], ...],
@@ -190,9 +190,86 @@ def _fallback_power_to_watts(
     return None
 
 
+def _fallback_energy_to_kwh(
+    data: dict[str, Any],
+    candidates: tuple[tuple[str, str | None, str], ...],
+) -> float | None:
+    """Read the first available same-meaning energy candidate as kWh."""
+    for value_key, unit_key, default_unit in candidates:
+        if data.get(value_key) not in (None, ""):
+            return _energy_to_kwh(data, value_key, unit_key, default_unit)
+    return None
+
+
+def _model_fallback_energy_to_kwh(
+    data: dict[str, Any],
+    candidates: tuple[tuple[str, str | None, str], ...],
+) -> float | None:
+    """Return optional model-specific energy from candidate fields."""
+    return _hide_grid_only_zero(data, _fallback_energy_to_kwh(data, candidates))
+
+
+def _signed_battery_power_to_watts(data: dict[str, Any]) -> float | None:
+    """Return battery power, applying Solis current sign when available."""
+    power = _model_power_to_watts(data, "batteryPower", "batteryPowerStr", "kW")
+    current = _fallback_float(
+        data, "storageBatteryCurrent", "bstteryCurrent", "batteryCurrent"
+    )
+    if power is not None and current is not None and current < 0:
+        return -abs(power)
+    if power is not None and current is not None and current > 0:
+        return abs(power)
+    return power
+
+
 def _fallback_float(data: dict[str, Any], *keys: str) -> float | None:
     """Read first available numeric field from same-meaning candidates."""
     return _first_float(data, *keys)
+
+
+def _pv_string_sensors(
+    start: int = 3, stop: int = 24
+) -> tuple[SolisSensorEntityDescription, ...]:
+    """Build extra PV string sensors based on solis-sensor's uPv/iPv/pow map."""
+    sensors: list[SolisSensorEntityDescription] = []
+    for index in range(start, stop + 1):
+        sensors.extend(
+            (
+                SolisSensorEntityDescription(
+                    key=f"pv{index}_voltage",
+                    translation_key=f"pv{index}_voltage",
+                    name=f"PV String {index} Voltage",
+                    native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+                    device_class=SensorDeviceClass.VOLTAGE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=1,
+                    value_fn=lambda data, i=index: _fallback_float(data, f"uPv{i}"),
+                ),
+                SolisSensorEntityDescription(
+                    key=f"pv{index}_current",
+                    translation_key=f"pv{index}_current",
+                    name=f"PV String {index} Current",
+                    native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+                    device_class=SensorDeviceClass.CURRENT,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=1,
+                    value_fn=lambda data, i=index: _fallback_float(data, f"iPv{i}"),
+                ),
+                SolisSensorEntityDescription(
+                    key=f"pv{index}_power",
+                    translation_key=f"pv{index}_power",
+                    name=f"PV String {index} Power",
+                    native_unit_of_measurement=UnitOfPower.WATT,
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=0,
+                    value_fn=lambda data, i=index: _fallback_float(
+                        data, f"pow{i}", f"Pow{i}"
+                    ),
+                ),
+            )
+        )
+    return tuple(sensors)
 
 
 def _total_pv_power_watts(data: dict[str, Any]) -> float:
@@ -391,6 +468,7 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         suggested_display_precision=0,
         value_fn=lambda data: _fallback_float(data, "pow2", "Pow2"),
     ),
+    *_pv_string_sensors(3, 24),
     # Grid AC / meter values exposed by inverterDetail
     SolisSensorEntityDescription(
         key="grid_l1_voltage",
@@ -503,7 +581,7 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: _model_power_to_watts(data, "batteryPower", "batteryPowerStr", "kW"),
+        value_fn=_signed_battery_power_to_watts,
     ),
     SolisSensorEntityDescription(
         key="battery_voltage",
@@ -513,7 +591,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_float(data, "storageBatteryVoltage", "batteryVoltage"),
+        value_fn=lambda data: _model_float(
+            data, "storageBatteryVoltage", "batteryVoltage"
+        ),
     ),
     SolisSensorEntityDescription(
         key="battery_current",
@@ -523,7 +603,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_float(data, "storageBatteryCurrent", "bstteryCurrent"),
+        value_fn=lambda data: _model_float(
+            data, "storageBatteryCurrent", "bstteryCurrent"
+        ),
     ),
     SolisSensorEntityDescription(
         key="battery_charge_today_energy",
@@ -533,7 +615,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "batteryTodayChargeEnergy", "batteryTodayChargeEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "batteryTodayChargeEnergy", "batteryTodayChargeEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="battery_charge_total_energy",
@@ -543,7 +627,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "batteryTotalChargeEnergy", "batteryTotalChargeEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "batteryTotalChargeEnergy", "batteryTotalChargeEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="battery_discharge_today_energy",
@@ -553,7 +639,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "batteryTodayDischargeEnergy", "batteryTodayDischargeEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "batteryTodayDischargeEnergy", "batteryTodayDischargeEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="battery_discharge_total_energy",
@@ -563,7 +651,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "batteryTotalDischargeEnergy", "batteryTotalDischargeEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "batteryTotalDischargeEnergy", "batteryTotalDischargeEnergyStr", "kWh"
+        ),
     ),
     # Load / backup values
     SolisSensorEntityDescription(
@@ -574,7 +664,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: _model_power_to_watts(data, "familyLoadPower", "familyLoadPowerStr", "kW"),
+        value_fn=lambda data: _model_power_to_watts(
+            data, "familyLoadPower", "familyLoadPowerStr", "kW"
+        ),
     ),
     SolisSensorEntityDescription(
         key="total_load_power",
@@ -584,7 +676,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: _model_power_to_watts(data, "totalLoadPower", "totalLoadPowerStr", "kW"),
+        value_fn=lambda data: _model_power_to_watts(
+            data, "totalLoadPower", "totalLoadPowerStr", "kW"
+        ),
     ),
     SolisSensorEntityDescription(
         key="bypass_load_power",
@@ -594,7 +688,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: _model_power_to_watts(data, "bypassLoadPower", "bypassLoadPowerStr", "kW"),
+        value_fn=lambda data: _model_power_to_watts(
+            data, "bypassLoadPower", "bypassLoadPowerStr", "kW"
+        ),
     ),
     SolisSensorEntityDescription(
         key="home_load_today_energy",
@@ -604,7 +700,18 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "homeLoadTodayEnergy", "homeLoadTodayEnergyStr", "kWh"),
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("homeLoadTodayEnergy", "homeLoadTodayEnergyStr", "kWh"),
+                ("station_homeLoadEnergy", "station_homeLoadEnergyStr", "kWh"),
+                (
+                    "station_homeLoadTodayEnergy",
+                    "station_homeLoadTodayEnergyStr",
+                    "kWh",
+                ),
+            ),
+        ),
     ),
     SolisSensorEntityDescription(
         key="home_load_total_energy",
@@ -614,7 +721,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "homeLoadTotalEnergy", "homeLoadTotalEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "homeLoadTotalEnergy", "homeLoadTotalEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="backup_load_today_energy",
@@ -624,7 +733,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "backupTodayEnergy", "backupTodayEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "backupTodayEnergy", "backupTodayEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="backup_load_total_energy",
@@ -634,7 +745,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "backupTotalEnergy", "backupTotalEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "backupTotalEnergy", "backupTotalEnergyStr", "kWh"
+        ),
     ),
     # Grid import/export energy
     SolisSensorEntityDescription(
@@ -645,7 +758,17 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "gridPurchasedTodayEnergy", "gridPurchasedTodayEnergyStr", "kWh"),
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridPurchasedTodayEnergy", "gridPurchasedTodayEnergyStr", "kWh"),
+                (
+                    "station_gridPurchasedDayEnergy",
+                    "station_gridPurchasedDayEnergyStr",
+                    "kWh",
+                ),
+            ),
+        ),
     ),
     SolisSensorEntityDescription(
         key="grid_import_total_energy",
@@ -655,7 +778,9 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "gridPurchasedTotalEnergy", "gridPurchasedTotalEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "gridPurchasedTotalEnergy", "gridPurchasedTotalEnergyStr", "kWh"
+        ),
     ),
     SolisSensorEntityDescription(
         key="grid_export_today_energy",
@@ -665,7 +790,13 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "gridSellTodayEnergy", "gridSellTodayEnergyStr", "kWh"),
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridSellTodayEnergy", "gridSellTodayEnergyStr", "kWh"),
+                ("station_gridSellDayEnergy", "station_gridSellDayEnergyStr", "kWh"),
+            ),
+        ),
     ),
     SolisSensorEntityDescription(
         key="grid_export_total_energy",
@@ -675,7 +806,85 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        value_fn=lambda data: _model_energy_to_kwh(data, "gridSellTotalEnergy", "gridSellTotalEnergyStr", "kWh"),
+        value_fn=lambda data: _model_energy_to_kwh(
+            data, "gridSellTotalEnergy", "gridSellTotalEnergyStr", "kWh"
+        ),
+    ),
+    SolisSensorEntityDescription(
+        key="grid_import_month_energy",
+        translation_key="grid_import_month_energy",
+        name="Grid Import This Month",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridPurchasedMonthEnergy", "gridPurchasedMonthEnergyStr", "kWh"),
+                (
+                    "station_gridPurchasedMonthEnergy",
+                    "station_gridPurchasedMonthEnergyStr",
+                    "kWh",
+                ),
+            ),
+        ),
+    ),
+    SolisSensorEntityDescription(
+        key="grid_import_year_energy",
+        translation_key="grid_import_year_energy",
+        name="Grid Import This Year",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridPurchasedYearEnergy", "gridPurchasedYearEnergyStr", "kWh"),
+                (
+                    "station_gridPurchasedYearEnergy",
+                    "station_gridPurchasedYearEnergyStr",
+                    "kWh",
+                ),
+            ),
+        ),
+    ),
+    SolisSensorEntityDescription(
+        key="grid_export_month_energy",
+        translation_key="grid_export_month_energy",
+        name="Grid Export This Month",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridSellMonthEnergy", "gridSellMonthEnergyStr", "kWh"),
+                (
+                    "station_gridSellMonthEnergy",
+                    "station_gridSellMonthEnergyStr",
+                    "kWh",
+                ),
+            ),
+        ),
+    ),
+    SolisSensorEntityDescription(
+        key="grid_export_year_energy",
+        translation_key="grid_export_year_energy",
+        name="Grid Export This Year",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: _model_fallback_energy_to_kwh(
+            data,
+            (
+                ("gridSellYearEnergy", "gridSellYearEnergyStr", "kWh"),
+                ("station_gridSellYearEnergy", "station_gridSellYearEnergyStr", "kWh"),
+            ),
+        ),
     ),
     # Diagnostics
     SolisSensorEntityDescription(
@@ -685,7 +894,13 @@ SENSOR_TYPES: tuple[SolisSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=["online", "offline", "unknown"],
-        value_fn=lambda data: None if data.get("collectorState") in (None, "") else {"1": "online", "2": "offline"}.get(str(data.get("collectorState")), "unknown"),
+        value_fn=lambda data: (
+            None
+            if data.get("collectorState") in (None, "")
+            else {"1": "online", "2": "offline"}.get(
+                str(data.get("collectorState")), "unknown"
+            )
+        ),
     ),
 )
 
@@ -706,7 +921,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SolisCloudSensor(CoordinatorEntity[SolisCloudDataUpdateCoordinator], SensorEntity):
+class SolisCloudSensor(
+    CoordinatorEntity[SolisCloudDataUpdateCoordinator], SensorEntity
+):
     """Representation of a Solis Cloud sensor."""
 
     entity_description: SolisSensorEntityDescription

--- a/tests/test_solis_borrowed_mappings.py
+++ b/tests/test_solis_borrowed_mappings.py
@@ -1,0 +1,219 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import sys
+import types
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Minimal Home Assistant stubs so we can unit-test the integration helpers
+# without installing a full Home Assistant runtime.
+ha = types.ModuleType("homeassistant")
+components = types.ModuleType("homeassistant.components")
+sensor_mod = types.ModuleType("homeassistant.components.sensor")
+
+
+class _SensorDeviceClass:
+    POWER = "power"
+    ENERGY = "energy"
+    VOLTAGE = "voltage"
+    CURRENT = "current"
+    BATTERY = "battery"
+    TEMPERATURE = "temperature"
+    FREQUENCY = "frequency"
+    DURATION = "duration"
+    ENUM = "enum"
+
+
+class _SensorStateClass:
+    MEASUREMENT = "measurement"
+    TOTAL_INCREASING = "total_increasing"
+
+
+class _SensorEntity:
+    pass
+
+
+@dataclass(frozen=True, kw_only=True)
+class _SensorEntityDescription:
+    key: str
+    translation_key: str | None = None
+    name: str | None = None
+    native_unit_of_measurement: str | None = None
+    device_class: str | None = None
+    state_class: str | None = None
+    suggested_display_precision: int | None = None
+    options: list[str] | None = None
+    entity_category: str | None = None
+
+
+sensor_mod.SensorDeviceClass = _SensorDeviceClass
+sensor_mod.SensorStateClass = _SensorStateClass
+sensor_mod.SensorEntity = _SensorEntity
+sensor_mod.SensorEntityDescription = _SensorEntityDescription
+config_entries = types.ModuleType("homeassistant.config_entries")
+config_entries.ConfigEntry = object
+const_mod = types.ModuleType("homeassistant.const")
+const_mod.PERCENTAGE = "%"
+const_mod.Platform = type("Platform", (), {"SENSOR": "sensor"})
+for name, vals in {
+    "UnitOfElectricCurrent": {"AMPERE": "A"},
+    "UnitOfElectricPotential": {"VOLT": "V"},
+    "UnitOfEnergy": {"KILO_WATT_HOUR": "kWh"},
+    "UnitOfFrequency": {"HERTZ": "Hz"},
+    "UnitOfPower": {"WATT": "W"},
+    "UnitOfTemperature": {"CELSIUS": "°C"},
+    "UnitOfTime": {"HOURS": "h"},
+}.items():
+    setattr(const_mod, name, type(name, (), vals))
+core_mod = types.ModuleType("homeassistant.core")
+core_mod.HomeAssistant = object
+entity_mod = types.ModuleType("homeassistant.helpers.entity")
+entity_mod.EntityCategory = type("EntityCategory", (), {"DIAGNOSTIC": "diagnostic"})
+platform_mod = types.ModuleType("homeassistant.helpers.entity_platform")
+platform_mod.AddEntitiesCallback = object
+typing_mod = types.ModuleType("homeassistant.helpers.typing")
+typing_mod.StateType = object
+update_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class _CoordinatorEntity:
+    def __class_getitem__(cls, item):
+        return cls
+
+    def __init__(self, coordinator=None):
+        self.coordinator = coordinator
+
+
+class _DataUpdateCoordinator:
+    def __class_getitem__(cls, item):
+        return cls
+
+    def __init__(self, hass, logger, name=None, update_interval=None):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+
+
+class _UpdateFailed(Exception):
+    pass
+
+
+update_mod.CoordinatorEntity = _CoordinatorEntity
+update_mod.DataUpdateCoordinator = _DataUpdateCoordinator
+update_mod.UpdateFailed = _UpdateFailed
+helpers = types.ModuleType("homeassistant.helpers")
+aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+aiohttp_client_mod.async_get_clientsession = lambda hass: None
+sys.modules.update(
+    {
+        "homeassistant": ha,
+        "homeassistant.components": components,
+        "homeassistant.components.sensor": sensor_mod,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.const": const_mod,
+        "homeassistant.core": core_mod,
+        "homeassistant.helpers": helpers,
+        "homeassistant.helpers.aiohttp_client": aiohttp_client_mod,
+        "homeassistant.helpers.entity": entity_mod,
+        "homeassistant.helpers.entity_platform": platform_mod,
+        "homeassistant.helpers.typing": typing_mod,
+        "homeassistant.helpers.update_coordinator": update_mod,
+    }
+)
+
+from custom_components.solis_cloud_monitoring.api import SolisCloudAPI
+from custom_components.solis_cloud_monitoring.const import API_STATION_DETAIL
+from custom_components.solis_cloud_monitoring.coordinator import _merge_station_detail
+from custom_components.solis_cloud_monitoring.sensor import SENSOR_TYPES
+
+
+def sensor_value(key, data):
+    desc = next(s for s in SENSOR_TYPES if s.key == key)
+    return desc.value_fn(data)
+
+
+def test_station_detail_endpoint_is_available_and_uses_station_id():
+    calls = []
+    api = SolisCloudAPI("key", "secret", object())
+
+    async def fake_request(endpoint, payload):
+        calls.append((endpoint, payload))
+        return {"stationName": "Home", "gridSellDayEnergy": "1.2"}
+
+    api._request = fake_request
+    result = asyncio.run(api.get_station_details("12345"))
+    assert result["gridSellDayEnergy"] == "1.2"
+    assert calls == [(API_STATION_DETAIL, {"id": "12345"})]
+
+
+def test_station_detail_values_are_merged_without_clobbering_inverter_detail():
+    inverter = {
+        "sn": "ABC",
+        "stationId": "123",
+        "familyLoadPower": "2.2",
+        "homeLoadTotalEnergy": "400",
+    }
+    station = {
+        "familyLoadPower": "9.9",
+        "homeLoadEnergy": "7.5",
+        "gridPurchasedDayEnergy": "3.1",
+        "gridSellYearEnergy": "123.4",
+    }
+    merged = _merge_station_detail(inverter, station)
+    assert merged["familyLoadPower"] == "2.2"
+    assert merged["station_homeLoadEnergy"] == "7.5"
+    assert merged["station_gridPurchasedDayEnergy"] == "3.1"
+    assert merged["station_gridSellYearEnergy"] == "123.4"
+
+
+def test_station_detail_fallbacks_feed_daily_and_yearly_grid_load_sensors():
+    data = {
+        "type": "2",
+        "station_homeLoadEnergy": "7.5",
+        "station_gridPurchasedDayEnergy": "3.1",
+        "station_gridSellYearEnergy": "123.4",
+    }
+    assert sensor_value("home_load_today_energy", data) == 7.5
+    assert sensor_value("grid_import_today_energy", data) == 3.1
+    assert sensor_value("grid_export_year_energy", data) == 123.4
+
+
+def test_battery_power_gets_discharge_sign_from_storage_current():
+    assert (
+        sensor_value(
+            "battery_power",
+            {
+                "type": "2",
+                "batteryPower": "1.25",
+                "batteryPowerStr": "kW",
+                "storageBatteryCurrent": "-12",
+            },
+        )
+        == -1250
+    )
+    assert (
+        sensor_value(
+            "battery_power",
+            {
+                "type": "2",
+                "batteryPower": "1.25",
+                "batteryPowerStr": "kW",
+                "storageBatteryCurrent": "12",
+            },
+        )
+        == 1250
+    )
+
+
+def test_pv_string_sensors_extend_to_pv24_like_solis_sensor():
+    assert sensor_value("pv24_voltage", {"uPv24": "620.5"}) == 620.5
+    assert sensor_value("pv24_current", {"iPv24": "8.1"}) == 8.1
+    assert sensor_value("pv24_power", {"Pow24": "5010"}) == 5010


### PR DESCRIPTION
Pulled across the safe bits from hultenvp/solis-sensor without bringing over the control stack or legacy service model.

What changed:
- add stationDetail polling as a fallback source for station-level grid/load energy values
- keep inverterDetail fields authoritative by namespacing stationDetail values before sensors read them
- add PV string sensors up to PV24 using the same uPv/iPv/pow pattern
- make battery power signed using storageBatteryCurrent, matching solis-sensor's behaviour
- add month/year grid import/export sensors from stationDetail fields
- add unit tests around the borrowed mappings so we do not regress the field choices

I deliberately did not copy the inverter control entities. That part is useful but much riskier and should be a separate decision.
